### PR TITLE
Add filtering for methods that can be replaced by LLVM intrinsics.

### DIFF
--- a/Zelig/Zelig/CompileTime/CodeGenerator/LLVMIR/BasicBlock.cpp
+++ b/Zelig/Zelig/CompileTime/CodeGenerator/LLVMIR/BasicBlock.cpp
@@ -221,6 +221,26 @@ void _BasicBlock::InsertMemCpy( _Value ^dst, _Value ^src )
     _pimpl->builder->CreateMemCpy( dst->_pimpl->GetLLVMObject( ), src->_pimpl->GetLLVMObject( ), dst->Type( )->GetSizeInBits( ) / 8, 0, false );
 }
 
+void _BasicBlock::InsertMemCpy( _Value ^dst, _Value ^src, _Value ^size, bool overlapping )
+{
+    dst = LoadToImmediate(dst);
+    src = LoadToImmediate(src);
+
+    assert( src != nullptr && dst != nullptr && size != nullptr );
+    assert( src->IsPointer( ) );
+    assert( dst->IsPointer( ) );
+    assert( size->IsInteger( ) );
+
+    if (overlapping)
+    {
+        _pimpl->builder->CreateMemMove( dst->_pimpl->GetLLVMObject( ), src->_pimpl->GetLLVMObject( ), size->_pimpl->GetLLVMObject( ), 0, false );
+    }
+    else
+    {
+        _pimpl->builder->CreateMemCpy( dst->_pimpl->GetLLVMObject( ), src->_pimpl->GetLLVMObject( ), size->_pimpl->GetLLVMObject( ), 0, false );
+    }
+}
+
 void _BasicBlock::InsertMemSet( _Value ^dst, unsigned char value )
 {
     dst = RevertImmediate( dst );

--- a/Zelig/Zelig/CompileTime/CodeGenerator/LLVMIR/BasicBlock.h
+++ b/Zelig/Zelig/CompileTime/CodeGenerator/LLVMIR/BasicBlock.h
@@ -70,6 +70,7 @@ public:
     void    InsertStoreIntoBT   ( _Value^ dst, _Value^ src );
     _Value^ LoadIndirect        ( _Value^ val, _Type^ ptrTy );
     void    InsertMemCpy        ( _Value^ dst, _Value^ src );
+    void    InsertMemCpy        ( _Value ^dst, _Value ^src, _Value ^size, bool overlapping );
     void    InsertMemSet        ( _Value^ dst, unsigned char value );
 
     //

--- a/Zelig/Zelig/RunTime/Zelig/Kernel/FrameworkOverrides/BufferImpl.cs
+++ b/Zelig/Zelig/RunTime/Zelig/Kernel/FrameworkOverrides/BufferImpl.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation.    All rights reserved.
 //
 
+#define LLVM
+
 namespace Microsoft.Zelig.Runtime
 {
     using System;
@@ -120,6 +122,10 @@ namespace Microsoft.Zelig.Runtime
         //--//--//
 
         [DisableNullChecks]
+#if LLVM
+        [NoInline] // Disable inlining so we always have a chance to replace the method.
+        [TS.WellKnownMethod("System_Buffer_InternalMemoryCopy")]
+#endif // LLVM
         internal unsafe static void InternalMemoryCopy( byte* src   ,
                                                         byte* dst   ,
                                                         int   count )
@@ -206,6 +212,9 @@ namespace Microsoft.Zelig.Runtime
                                                         ushort* dst   ,
                                                         int     count )
         {
+#if LLVM
+            InternalMemoryCopy((byte*)src, (byte*)dst, count * sizeof(ushort));
+#else // LLVM
             BugCheck.Assert( count >= 0, BugCheck.StopCode.NegativeIndex );
 
             if(AddressMath.IsAlignedTo32bits( src ) &&
@@ -258,6 +267,7 @@ namespace Microsoft.Zelig.Runtime
                     dst[0] = src[0];
                 }
             }
+#endif // LLVM
         }
 
         [Inline]
@@ -283,6 +293,9 @@ namespace Microsoft.Zelig.Runtime
                                                         uint* dst   ,
                                                         int   count )
         {
+#if LLVM
+            InternalMemoryCopy((byte*)src, (byte*)dst, count * sizeof(uint));
+#else // LLVM
             BugCheck.Assert( count >= 0, BugCheck.StopCode.NegativeIndex );
 
             if(count > 0)
@@ -321,6 +334,7 @@ namespace Microsoft.Zelig.Runtime
                     dst[0] = src[0];
                 }
             }
+#endif // LLVM
         }
 
         [Inline]
@@ -334,6 +348,10 @@ namespace Microsoft.Zelig.Runtime
         //--//--//
 
         [DisableNullChecks]
+#if LLVM
+        [NoInline] // Disable inlining so we always have a chance to replace the method.
+        [TS.WellKnownMethod("System_Buffer_InternalBackwardMemoryCopy")]
+#endif // LLVM
         internal unsafe static void InternalBackwardMemoryCopy( byte* src   ,
                                                                 byte* dst   ,
                                                                 int   count )
@@ -436,6 +454,9 @@ namespace Microsoft.Zelig.Runtime
                                                                 ushort* dst   ,
                                                                 int     count )
         {
+#if LLVM
+            InternalBackwardMemoryCopy((byte*)src, (byte*)dst, count * sizeof(ushort));
+#else // LLVM
             BugCheck.Assert( count >= 0, BugCheck.StopCode.NegativeIndex );
 
             src += count;
@@ -499,6 +520,7 @@ namespace Microsoft.Zelig.Runtime
                     dst[0] = src[0];
                 }
             }
+#endif // LLVM
         }
 
         [Inline]
@@ -524,6 +546,9 @@ namespace Microsoft.Zelig.Runtime
                                                                 uint* dst   ,
                                                                 int   count )
         {
+#if LLVM
+            InternalBackwardMemoryCopy((byte*)src, (byte*)dst, count * sizeof(uint));
+#else // LLVM
             BugCheck.Assert( count >= 0, BugCheck.StopCode.NegativeIndex );
 
             if(count > 0)
@@ -568,6 +593,7 @@ namespace Microsoft.Zelig.Runtime
                     dst[0] = src[0];
                 }
             }
+#endif // LLVM
         }
 
         [Inline]

--- a/Zelig/Zelig/RunTime/Zelig/TypeSystem/WellKnownMethods.cs
+++ b/Zelig/Zelig/RunTime/Zelig/TypeSystem/WellKnownMethods.cs
@@ -61,6 +61,9 @@ namespace Microsoft.Zelig.Runtime.TypeSystem
         public readonly MethodRepresentation Object_Equals;
         public readonly MethodRepresentation Object_GetHashCode;
 
+        public readonly MethodRepresentation System_Buffer_InternalMemoryCopy;
+        public readonly MethodRepresentation System_Buffer_InternalBackwardMemoryCopy;
+
         public readonly MethodRepresentation Helpers_BinaryOperations_IntDiv;
         public readonly MethodRepresentation Helpers_BinaryOperations_IntRem;
 


### PR DESCRIPTION
This is currently limited to memcpy and memmove, but enables others to be added on a case-by-case basis.

Resolves #18.
