### PR TITLE
Work around LLVM issue for static readonly primitive arrays.

### DIFF
--- a/Zelig/Zelig/CompileTime/CodeGenerator/CodeTransformation/CompilationSteps/PhaseDrivers/DetectFieldInvariants.cs
+++ b/Zelig/Zelig/CompileTime/CodeGenerator/CodeTransformation/CompilationSteps/PhaseDrivers/DetectFieldInvariants.cs
@@ -138,6 +138,17 @@ namespace Microsoft.Zelig.CodeGeneration.IR.CompilationSteps
                                                 if(tElement != null)
                                                 {
                                                     array = Array.CreateInstance( tElement, size );
+
+                                                    if(typeSystem.PlatformAbstraction.PlatformName == "LLVM")
+                                                    {
+                                                        // BUGBUG: ColinA-MSFT: LLVM likes to optimize zero arrays away, and make them zero-length.
+                                                        // However, we need these arrays to be their actual size in memory, so we must set at least
+                                                        // one non-zero element. This workaround should be removed when we fix this on the LLVM side.
+                                                        if (tElement.IsPrimitive && (size > 0))
+                                                        {
+                                                            array.SetValue(Convert.ChangeType(1, tElement), 0);
+                                                        }
+                                                    }
                                                 }
 
                                                 DataManager.Attributes flags = DataManager.Attributes.SuitableForConstantPropagation;

--- a/Zelig/Zelig/RunTime/Framework/mscorlib/System/String.cs
+++ b/Zelig/Zelig/RunTime/Framework/mscorlib/System/String.cs
@@ -56,10 +56,7 @@ namespace System
         //We need to call the String constructor so that the compiler doesn't mark this as a literal.
         //Marking this as a literal would mean that it doesn't show up as a field which we can access
         //from native.
-
-        //MIGUEL: LT72: Switched to const to avoid calling .cctor until we fix it
-        //public static readonly String Empty = "";
-        public const String Empty = "";
+        public static readonly String Empty = "";
 
         //
         //NOTE NOTE NOTE NOTE


### PR DESCRIPTION
LLVM replaces all-zero arrays with ConstAggregateZero. This has an unfortunate side effect of also truncating the array to zero length. This workaround unblocks other work until we can address the root issue.

Related: #17 
